### PR TITLE
changed port from 8080 to 8081

### DIFF
--- a/getting_started/first-app.rst
+++ b/getting_started/first-app.rst
@@ -31,9 +31,9 @@ Accessing the Traefik UI
 
 One simple and quick way to access the Traefik UI is to tunnel via SSH to one of the edge nodes with the following command::
 
-    ssh -N -f -L localhost:8080:localhost:8080 ubuntu@<your-domain>
+    ssh -N -f -L localhost:8081:localhost:8081 ubuntu@<your-domain>
 
-Using SSH tunnelling, the Traefik UI should be reachable at http://localhost:8080, and it should look something like this:
+Using SSH tunnelling, the Traefik UI should be reachable at http://localhost:8081, and it should look something like this:
 
 .. image:: ../img/traefik_UI_example.png
 


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please make sure to read the contributing guideline before you proceed: https://github.com/kubenow/KubeNow/blob/master/CONTRIBUTING.md
-->

## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->
The PR updates documentation. Traefik is now available on port 8081 and not on 8080 anymore.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
**Docs**: <!-- kubenow/docs#X, kubenow/docs#Y, ... kubenow/docs#Z -->
